### PR TITLE
Change gerrit urls for shh config support

### DIFF
--- a/var/spack/repos/builtin/packages/atmi/package.py
+++ b/var/spack/repos/builtin/packages/atmi/package.py
@@ -14,7 +14,7 @@ class Atmi(CMakePackage):
     (integrated and discrete)."""
 
     homepage = "https://github.com/RadeonOpenCompute/atmi"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/atmi"
+    git = "ssh://gerritgit/compute/ec/atmi"
     url = "https://github.com/RadeonOpenCompute/atmi/archive/rocm-5.4.3.tar.gz"
     tags = ["rocm"]
 

--- a/var/spack/repos/builtin/packages/comgr/package.py
+++ b/var/spack/repos/builtin/packages/comgr/package.py
@@ -13,7 +13,7 @@ class Comgr(CMakePackage):
     contains one library, the Code Object Manager (Comgr)"""
 
     homepage = "https://github.com/RadeonOpenCompute/ROCm-CompilerSupport"
-    git =  "ssh://<user-id>@gerrit-git.amd.com:<port-number>/lightning/ec/support.git"
+    git =  "ssh://gerritgit/lightning/ec/support.git"
     url = "https://github.com/RadeonOpenCompute/ROCm-CompilerSupport/archive/rocm-5.4.3.tar.gz"
     tags = ["rocm"]
 

--- a/var/spack/repos/builtin/packages/hip-rocclr/package.py
+++ b/var/spack/repos/builtin/packages/hip-rocclr/package.py
@@ -13,7 +13,7 @@ class HipRocclr(CMakePackage):
     runtimes to work on Windows as well as on Linux without much effort."""
 
     homepage = "https://github.com/ROCm-Developer-Tools/ROCclr"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/vdi.git"
+    git = "ssh://gerritgit/compute/ec/vdi.git"
     tags = ["rocm"]
 
     phases = ["cmake", "build"]
@@ -93,7 +93,7 @@ class HipRocclr(CMakePackage):
     )
     resource(
         name="opencl-on-vdi",
-        git= "ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/opencl.git",
+        git= "ssh://gerritgit/compute/ec/opencl.git",
         destination="",
         placement="opencl-on-vdi",
         branch="amd-staging-closed",

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -17,7 +17,7 @@ class Hip(CMakePackage):
     single source code."""
 
     homepage = "https://github.com/ROCm/HIP"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/hip"
+    git = "ssh://gerritgit/compute/ec/hip"
     url = "https://github.com/ROCm/HIP/archive/rocm-6.0.2.tar.gz"
     tags = ["rocm"]
 
@@ -214,7 +214,7 @@ class Hip(CMakePackage):
         )
     resource(
         name="clr",
-        git="ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/clr.git",
+        git="ssh://gerritgit/compute/ec/clr.git",
         expand=True,
         destination="",
         branch="amd-staging",
@@ -255,7 +255,7 @@ class Hip(CMakePackage):
         )
     resource(
         name="hipcc",
-        git="ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/hipcc.git",
+        git="ssh://gerritgit/compute/ec/hipcc.git",
         expand=True,
         destination="",
         branch="amd-stg-open",
@@ -303,7 +303,7 @@ class Hip(CMakePackage):
         )
     resource(
         name="hip-tests",
-        git="ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/hip-tests.git",
+        git="ssh://gerritgit/compute/ec/hip-tests.git",
         expand=True,
         destination="",
         branch="amd-staging",

--- a/var/spack/repos/builtin/packages/hipcc/package.py
+++ b/var/spack/repos/builtin/packages/hipcc/package.py
@@ -12,7 +12,7 @@ class Hipcc(CMakePackage):
     """HIPCC: HIP compiler driver"""
 
     homepage = "https://github.com/ROCm/hipcc"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/lightning/ec/llvm-project.git"
+    git = "ssh://gerritgit/lightning/ec/llvm-project.git"
 
     def url_for_version(self, version):
         if version <= Version("6.0.2"):

--- a/var/spack/repos/builtin/packages/hipify-clang/package.py
+++ b/var/spack/repos/builtin/packages/hipify-clang/package.py
@@ -11,7 +11,7 @@ class HipifyClang(CMakePackage):
     sources into HIP sources"""
 
     homepage = "https://github.com/ROCm/HIPIFY"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/hipify.git"
+    git = "ssh://gerritgit/compute/ec/hipify.git"
     url = "https://github.com/ROCm/HIPIFY/archive/rocm-6.0.2.tar.gz"
     tags = ["rocm"]
 
@@ -47,8 +47,8 @@ class HipifyClang(CMakePackage):
 
     patch("0001-install-hipify-clang-in-bin-dir-and-llvm-clangs-head.patch", when="@5.1.0:5.5")
     patch("0002-install-hipify-clang-in-bin-dir-and-llvm-clangs-head.patch", when="@5.6")
-    #patch("0003-install-hipify-clang-in-bin-dir-and-llvm-clangs-head.patch", when="@develop")
-    patch("0004-install-hipify-clang-in-bin-dir-and-llvm-clangs-head.patch", when="@develop")
+    patch("0003-install-hipify-clang-in-bin-dir-and-llvm-clangs-head.patch", when="@develop")
+    #patch("0004-install-hipify-clang-in-bin-dir-and-llvm-clangs-head.patch", when="@develop")
     patch("0002-install-hipify-clang-in-bin-dir-and-llvm-clangs-head.patch", when="@5.6:6.0")
     patch("0003-install-hipify-clang-in-bin-dir-and-llvm-clangs-head.patch", when="@6.1")
 

--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
@@ -16,7 +16,7 @@ class HsaRocrDev(CMakePackage):
     Linux HSA Runtime for Boltzmann (ROCm) platforms."""
 
     homepage = "https://github.com/ROCm/ROCR-Runtime"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/hsa/ec/hsa-runtime.git"
+    git = "ssh://gerritgit/hsa/ec/hsa-runtime.git"
     url = "https://github.com/ROCm/ROCR-Runtime/archive/rocm-6.0.2.tar.gz"
     tags = ["rocm"]
 

--- a/var/spack/repos/builtin/packages/hsakmt-roct/package.py
+++ b/var/spack/repos/builtin/packages/hsakmt-roct/package.py
@@ -15,7 +15,7 @@ class HsakmtRoct(CMakePackage):
     with the ROCk driver."""
 
     homepage = "https://github.com/ROCm/ROCT-Thunk-Interface"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/libhsakmt.git"
+    git = "ssh://gerritgit/compute/ec/libhsakmt.git"
     url = "https://github.com/ROCm/ROCT-Thunk-Interface/archive/rocm-6.0.2.tar.gz"
     tags = ["rocm"]
 

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -14,7 +14,7 @@ class LlvmAmdgpu(CMakePackage, CompilerPackage):
     optimizers, and run-time environments."""
 
     homepage = "https://github.com/ROCm/llvm-project"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/lightning/ec/llvm-project.git"
+    git = "ssh://gerritgit/lightning/ec/llvm-project.git"
     url = "https://github.com/ROCm/llvm-project/archive/rocm-6.0.2.tar.gz"
     tags = ["rocm"]
     executables = [r"amdclang", r"amdclang\+\+", r"amdflang", r"clang.*", r"flang.*", "llvm-.*"]
@@ -152,7 +152,7 @@ class LlvmAmdgpu(CMakePackage, CompilerPackage):
     resource(
         name="rocm-device-libs",
         placement="rocm-device-libs",
-        git="ssh://<user-id>@gerrit-git.amd.com:<port-number>/lightning/ec/device-libs.git",
+        git="ssh://gerritgit/lightning/ec/device-libs.git",
         branch="amd-stg-open",
         when="@develop +rocm-device-libs",
     )
@@ -178,7 +178,7 @@ class LlvmAmdgpu(CMakePackage, CompilerPackage):
     resource(
         name="hsa-runtime",
         placement="hsa-runtime",
-        git="ssh://<user-id>@gerrit-git.amd.com:<port-number>/hsa/ec/hsa-runtime.git",
+        git="ssh://gerritgit/hsa/ec/hsa-runtime.git",
         branch="amd-staging",
         when="@develop",
     )
@@ -208,7 +208,7 @@ class LlvmAmdgpu(CMakePackage, CompilerPackage):
     resource(
         name="comgr",
         placement="comgr",
-        git= "ssh://<user-id>@gerrit-git.amd.com:<port-number>/lightning/ec/support.git",
+        git= "ssh://gerritgit/lightning/ec/support.git",
         branch="amd-stg-open",
         when="@develop",
     )

--- a/var/spack/repos/builtin/packages/rocm-bandwidth-test/package.py
+++ b/var/spack/repos/builtin/packages/rocm-bandwidth-test/package.py
@@ -11,7 +11,7 @@ class RocmBandwidthTest(CMakePackage):
     """Test to measure PciE bandwidth on ROCm platforms"""
 
     homepage = "https://github.com/RadeonOpenCompute/rocm_bandwidth_test"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/rocm_bandwidth_test.git"
+    git = "ssh://gerritgit/compute/ec/rocm_bandwidth_test.git"
     url = "https://github.com/RadeonOpenCompute/rocm_bandwidth_test/archive/rocm-5.5.0.tar.gz"
     tags = ["rocm"]
 

--- a/var/spack/repos/builtin/packages/rocm-clang-ocl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-clang-ocl/package.py
@@ -10,7 +10,7 @@ class RocmClangOcl(CMakePackage):
     """OpenCL compilation with clang compiler"""
 
     homepage = "https://github.com/RadeonOpenCompute/clang-ocl"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/clang-ocl.git"
+    git = "ssh://gerritgit/compute/ec/clang-ocl.git"
     url = "https://github.com/RadeonOpenCompute/clang-ocl/archive/rocm-5.4.3.tar.gz"
     tags = ["rocm"]
 

--- a/var/spack/repos/builtin/packages/rocm-cmake/package.py
+++ b/var/spack/repos/builtin/packages/rocm-cmake/package.py
@@ -12,7 +12,7 @@ class RocmCmake(CMakePackage):
     in the ROCm software stack"""
 
     homepage = "https://github.com/RadeonOpenCompute/rocm-cmake"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/packaging/rocm-cmake.git"
+    git = "ssh://gerritgit/compute/ec/packaging/rocm-cmake.git"
     url = "https://github.com/RadeonOpenCompute/rocm-cmake/archive/rocm-5.6.0.tar.gz"
     tags = ["rocm"]
 

--- a/var/spack/repos/builtin/packages/rocm-core/package.py
+++ b/var/spack/repos/builtin/packages/rocm-core/package.py
@@ -13,7 +13,7 @@ class RocmCore(CMakePackage):
     getROCmVersion function provides the ROCm version."""
 
     homepage = "https://github.com/RadeonOpenCompute/rocm-core"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/rocm-core.git"
+    git = "ssh://gerritgit/compute/ec/rocm-core.git"
     url = "https://github.com/RadeonOpenCompute/rocm-core/archive/refs/tags/rocm-5.5.0.tar.gz"
     tags = ["rocm"]
 

--- a/var/spack/repos/builtin/packages/rocm-dbgapi/package.py
+++ b/var/spack/repos/builtin/packages/rocm-dbgapi/package.py
@@ -15,7 +15,7 @@ class RocmDbgapi(CMakePackage):
     AMD's commercially available GPU architectures."""
 
     homepage = "https://github.com/ROCm-Developer-Tools/ROCdbgapi"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/rocm-dbgapi.git"
+    git = "ssh://gerritgit/compute/ec/rocm-dbgapi.git"
     url = "https://github.com/ROCm-Developer-Tools/ROCdbgapi/archive/rocm-5.4.3.tar.gz"
     tags = ["rocm"]
 

--- a/var/spack/repos/builtin/packages/rocm-debug-agent/package.py
+++ b/var/spack/repos/builtin/packages/rocm-debug-agent/package.py
@@ -12,7 +12,7 @@ class RocmDebugAgent(CMakePackage):
     """Radeon Open Compute (ROCm) debug agent"""
 
     homepage = "https://github.com/ROCm-Developer-Tools/rocr_debug_agent"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/DevTools/ec/rocr_debug_agent.git"
+    git = "ssh://gerritgit/DevTools/ec/rocr_debug_agent.git"
     url = "https://github.com/ROCm-Developer-Tools/rocr_debug_agent/archive/rocm-5.5.0.tar.gz"
     tags = ["rocm"]
 

--- a/var/spack/repos/builtin/packages/rocm-device-libs/package.py
+++ b/var/spack/repos/builtin/packages/rocm-device-libs/package.py
@@ -11,7 +11,7 @@ class RocmDeviceLibs(CMakePackage):
     """set of AMD specific device-side language runtime libraries"""
 
     homepage = "https://github.com/ROCm/ROCm-Device-Libs"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/lightning/ec/device-libs.git"
+    git = "ssh://gerritgit/lightning/ec/device-libs.git"
     url = "https://github.com/ROCm/ROCm-Device-Libs/archive/rocm-6.0.2.tar.gz"
     tags = ["rocm"]
 

--- a/var/spack/repos/builtin/packages/rocm-gdb/package.py
+++ b/var/spack/repos/builtin/packages/rocm-gdb/package.py
@@ -12,7 +12,7 @@ class RocmGdb(AutotoolsPackage):
     based on GDB, the GNU source-level debugger."""
 
     homepage = "https://github.com/ROCm-Developer-Tools/ROCgdb/"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/rocm-gdb"
+    git = "ssh://gerritgit/compute/ec/rocm-gdb"
     url = "https://github.com/ROCm-Developer-Tools/ROCgdb/archive/rocm-5.5.0.tar.gz"
     tags = ["rocm"]
 

--- a/var/spack/repos/builtin/packages/rocm-opencl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-opencl/package.py
@@ -14,7 +14,7 @@ class RocmOpencl(CMakePackage):
     """OpenCL: Open Computing Language on ROCclr"""
 
     homepage = "https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/opencl.git"
+    git = "ssh://gerritgit/compute/ec/opencl.git"
     tags = ["rocm"]
 
     maintainers("srekolam", "renjithravindrankannath")
@@ -90,7 +90,7 @@ class RocmOpencl(CMakePackage):
         )
     resource(
         name="rocclr",
-        git= "ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/vdi.git",
+        git= "ssh://gerritgit/compute/ec/vdi.git",
         destination="",
         placement="rocclr",
         branch="amd-staging-closed",

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -258,7 +258,7 @@ class RocmOpenmpExtras(Package):
 
         resource(
             name="rocm-device-libs",
-            git=f"ssh://<user-id>@gerrit-git.amd.com:<port-number>/lightning/ec/device-libs.git",
+            git=f"ssh://gerritgit/lightning/ec/device-libs.git",
             branch="amd-stg-open",
             expand=True,
             destination="rocm-openmp-extras",
@@ -268,7 +268,7 @@ class RocmOpenmpExtras(Package):
 
         resource(
             name="flang",
-            git=f"ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/flang.git",
+            git=f"ssh://gerritgit/compute/ec/flang.git",
             branch="amd-mainline-open",
             expand=True,
             destination="rocm-openmp-extras",
@@ -278,7 +278,7 @@ class RocmOpenmpExtras(Package):
 
         resource(
             name="aomp-extras",
-            git=f"ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/aomp-extras.git",
+            git=f"ssh://gerritgit/compute/ec/aomp-extras.git",
             branch="amd-mainline-open",
             expand=True,
             destination="rocm-openmp-extras",
@@ -288,7 +288,7 @@ class RocmOpenmpExtras(Package):
 
         resource(
             name="llvm-project",
-            git=f"ssh://<user-id>@gerrit-git.amd.com:<port-number>/lightning/ec/llvm-project.git",
+            git=f"ssh://gerritgit/lightning/ec/llvm-project.git",
             branch="amd-staging",
             expand=True,
             destination="rocm-openmp-extras",

--- a/var/spack/repos/builtin/packages/rocm-smi-lib/package.py
+++ b/var/spack/repos/builtin/packages/rocm-smi-lib/package.py
@@ -16,7 +16,7 @@ class RocmSmiLib(CMakePackage):
     for applications to monitor and control GPU applications."""
 
     homepage = "https://github.com/ROCm/rocm_smi_lib"
-    git  = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/rocm_smi_lib.git"
+    git  = "ssh://gerritgit/compute/ec/rocm_smi_lib.git"
     url = "https://github.com/ROCm/rocm_smi_lib/archive/rocm-6.0.2.tar.gz"
     tags = ["rocm"]
 

--- a/var/spack/repos/builtin/packages/rocminfo/package.py
+++ b/var/spack/repos/builtin/packages/rocminfo/package.py
@@ -11,7 +11,7 @@ class Rocminfo(CMakePackage):
     """Radeon Open Compute (ROCm) Runtime rocminfo tool"""
 
     homepage = "https://github.com/ROCm/rocminfo"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/rocminfo"
+    git = "ssh://gerritgit/compute/ec/rocminfo"
     url = "https://github.com/ROCm/rocminfo/archive/rocm-6.0.2.tar.gz"
     tags = ["rocm"]
 

--- a/var/spack/repos/builtin/packages/roctracer-dev-api/package.py
+++ b/var/spack/repos/builtin/packages/roctracer-dev-api/package.py
@@ -12,7 +12,7 @@ class RoctracerDevApi(Package):
     For the ROC-tracer library, please check out roctracer-dev."""
 
     homepage = "https://github.com/ROCm/roctracer"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/roctracer.git"
+    git = "ssh://gerritgit/compute/ec/roctracer.git"
     url = "https://github.com/ROCm/roctracer/archive/refs/tags/rocm-6.0.2.tar.gz"
     tags = ["rocm"]
 

--- a/var/spack/repos/builtin/packages/roctracer-dev/package.py
+++ b/var/spack/repos/builtin/packages/roctracer-dev/package.py
@@ -14,7 +14,7 @@ class RoctracerDev(CMakePackage, ROCmPackage):
     specific runtime profiler to trace API and asyncronous activity."""
 
     homepage = "https://github.com/ROCm/roctracer"
-    git = "ssh://<user-id>@gerrit-git.amd.com:<port-number>/compute/ec/roctracer.git"
+    git = "ssh://gerritgit/compute/ec/roctracer.git"
     url = "https://github.com/ROCm/roctracer/archive/rocm-6.0.2.tar.gz"
     tags = ["rocm"]
 


### PR DESCRIPTION
https://ontrack-internal.amd.com/browse/ROCMOPS-7457

Needs to be merged before: https://github.com/ROCm/rocm-spack/pull/170

Allows github runners to use private gerrit repo

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
