### PR TITLE
add linux nightly build for rocm-spack-ci-changes

### DIFF
--- a/.github/workflows/nightly-lin-builds.yml
+++ b/.github/workflows/nightly-lin-builds.yml
@@ -1,0 +1,90 @@
+name: Linux Install Nightly
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # Run at 2 am
+
+jobs:
+  setup:
+    runs-on:  [self-hosted, Linux]
+    steps:
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      with:
+        ref: rocm-spack-ci-changes
+
+    - name: Install  essential utilities
+      run: |
+          apt-get update -y
+          apt-get install -y make patch bash tar gzip unzip bzip2 file gnupg2 git gawk
+          apt-get update -y
+          apt-get install -y xz-utils
+          apt-get install -y build-essential
+          apt-get install -y vim
+          
+    - name: Install Python
+      run: |
+          apt-get install -y python3
+          apt-get upgrade -y python3-pip
+
+    - name : Install Compilers
+      run: |
+          apt-get install -y gcc
+          apt-get install -y gfortran
+
+    - name : Initialize Spack
+      run: |
+          . share/spack/setup-env.sh
+          spack --version
+          
+  install-rocm:
+    needs: setup
+    runs-on: [self-hosted, Linux]
+    strategy:
+      matrix:
+        component: [
+          "rocm-cmake",
+          "hsakmt-roct",
+          "rocm-smi-lib",
+          "hsa-rocr-dev",
+          "llvm-amdgpu",
+          "rocm-device-libs",
+          "comgr",
+          "hipify-clang",
+          "hip",
+          "hipcc",
+          "rocminfo",
+          "rccl",
+          "rocm-debug-agent",
+          "rocm-bandwidth-test",
+          "rocprofiler-dev",
+          "roctracer-dev-api",
+          "roctracer-dev",
+          "rocm-dbgapi",
+          "rocm-gdb",
+          "rocm-openmp-extras"
+        ]
+    steps:
+      - name: Install ROCm components
+        id: install
+        continue-on-error: true
+        run: |
+          . share/spack/setup-env.sh
+          spack install ${{ matrix.component }}@develop
+      
+      - name: Save installation result
+        if: ${{ steps.install.outcome == 'failure' }}
+        run: echo "${{ matrix.component }}" >> failed_components.txt
+          
+  report-failures:
+    needs: install-rocm
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Report ROCm component installation status
+        run: |
+          if [ -f failed_components.txt ]; then
+            echo "Failed to install the following ROCm components:"
+            cat failed_components.txt
+            exit 1
+          else
+            echo "All components installed successfully."
+          fi


### PR DESCRIPTION
https://ontrack-internal.amd.com/browse/ROCMOPS-7457

Adds a nightly build to the Spack repo

This first job aims to follow the instructions found here: https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/spack.html

next steps include:
- Dockerizing the CI
- add functionality to build on multiple distros
- add Phase 2 of ROCm components

depends on https://github.com/ROCm/rocm-spack/pull/164

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
