### PR TITLE
Remove hsakmt-roct from nightly Linux tests

### DIFF
--- a/.github/workflows/nightly-lin-builds.yml
+++ b/.github/workflows/nightly-lin-builds.yml
@@ -43,7 +43,6 @@ jobs:
       matrix:
         component: [
           "rocm-cmake",
-          "hsakmt-roct",
           "rocm-smi-lib",
           "hsa-rocr-dev",
           "llvm-amdgpu",


### PR DESCRIPTION
As requested by @afzpatel: removing hsakmt-roct as it's deprecated and doesn't need to be tested

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
